### PR TITLE
fix(pandas3): restore sanitize()/get_valid under pandas 3.0

### DIFF
--- a/src/tyssue/core/objects.py
+++ b/src/tyssue/core/objects.py
@@ -681,10 +681,18 @@ class Epithelium:
         """Set the 'is_valid' column to true if the faces are all closed polygons,
         and the cells closed polyhedra.
         """
-        is_valid_face = self.edge_df.groupby("face").apply(_test_valid, include_groups=True)
+        # pandas 3.0 removed `include_groups` and now excludes the grouping
+        # column from each group; but `_test_valid`/`_ordered_edges` need the
+        # `face` column. Re-add it inside apply from the group key (`g.name`),
+        # reproducing the old include_groups=True behaviour.
+        is_valid_face = self.edge_df.groupby("face").apply(
+            lambda g: _test_valid(g.assign(face=g.name))
+        )
         is_valid = self.upcast_face(is_valid_face)
         if "cell" in self.data_names:
-            is_valid_cell = self.edge_df.groupby("cell").apply(_is_closed_cell)
+            is_valid_cell = self.edge_df.groupby("cell").apply(
+                lambda g: _is_closed_cell(g.assign(cell=g.name))
+            )
             is_valid = np.logical_and(is_valid, self.upcast_cell(is_valid_cell))
         self.edge_df["is_valid"] = is_valid
         return is_valid


### PR DESCRIPTION
## Intention / context

Part of the **tyssue Rust-backend speedup effort** (downstream
vivarium-collective/vivarium-tyssue#18): swap tyssue's per-step hot loop for a
Rust backend to massively speed up simulation and scale the number of cells,
while keeping existing demos working. This fix is a **prerequisite for
larger-mesh scaling** — without a working `sanitize()`, no new/bigger meshes can
be generated under pandas 3, so the cells-vs-time scaling curve (currently to
~1500 cells, ~3× rust speedup sustained) can't be extended.

## Problem

Under pandas 3.0, `sanitize()` (and therefore all mesh generation —
`planar_sheet_2d`, etc.) is broken:

```
ValueError: include_groups=True is no longer allowed.
```

`Epithelium.get_valid()` used `groupby("face").apply(_test_valid, include_groups=True)`.
pandas 3.0 removed the `include_groups` argument and now **excludes** the
grouping column from each group. But `_test_valid` → `_ordered_edges` reads the
`face` column (it returns srce/trgt/**face**/edge indices), so simply dropping
the argument yields `KeyError: ['face'] not in index`.

## Fix

Re-add the grouping column inside `apply` from the group key (`g.name`), for
both the face and cell validity checks — reproducing the old
`include_groups=True` behaviour without the removed argument.

## Verification

- `planar_sheet_2d(8,8).sanitize(trim_borders=True)` now runs (Nf 64 → 42).
- Generated sheets drive `SheetGeometry.update_all` + the standard sheet model
  end-to-end, and feed the downstream scaling benchmark (42 → 1482 cells).
- Downstream consumer (vivarium-tyssue) full demo suite stays green (61 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)